### PR TITLE
Read meta schema from deterministic location

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Or install it yourself as:
 
 ## Usage
 
-Combine takes the path to a directory of schemas and combines them into a schema.json file in the current directory. If a meta.json file exists, it will also be combined to override defaults/metadata.
+Combine takes the path to a directory of schemas and combines them into a schema.json file in the current directory. If a `_meta.json` file exists, it will also be combined to override defaults/metadata.
 
 ```
 prmd combine $DIRECTORY


### PR DESCRIPTION
Currently, the code tries to read the meta schema file (`meta.json`)
from the current directory where `prmd` is being run. This isn't
desirable in cases where you're building a schema nested several layers
deep.

To avoid naming conflicts with other resources, I've renamed `meta.json`
to `_meta.json`.  Another alternative might be to read it from the
parent directory.

I don't think this change will break anybody because the meta code
currently fails due to an invalid variable being referenced (`schema`).

/cc @geemus
