### PR TITLE
allow type to be a single string instead of always an array

### DIFF
--- a/lib/prmd/doc.rb
+++ b/lib/prmd/doc.rb
@@ -42,6 +42,11 @@ end
 def extract_attributes(schemata, properties)
   attributes = []
   properties.each do |key, value|
+    #normalize single value types to arrays
+    if value['type'].is_a?(String)
+      value['type'] = [value['type']]
+    end
+
     # found a reference to another element:
     if value.has_key?('anyOf')
       descriptions = []


### PR DESCRIPTION
Instead of always having to do:

```
-      "type" : [
-        "string"
-      ],
```

We can clean up our json a lot by doing:

 `"type" : "string"`
