### PR TITLE
Allow to have non-json files in the directory

### DIFF
--- a/lib/prmd/doc.rb
+++ b/lib/prmd/doc.rb
@@ -104,7 +104,7 @@ end
 module Prmd
   def self.doc(directory)
     schemata = {}
-    Dir.glob(File.join(directory, '*.*')).each do |path|
+    Dir.glob(File.join(directory, '*.json')).each do |path|
       data = JSON.parse(File.read(path))
       schemata[data['id']] = data
     end


### PR DESCRIPTION
This is more flexible that the current state, where prmd crash if anything not json is found.
