### PR TITLE
Make verify command accept stdin input

### DIFF
--- a/bin/prmd
+++ b/bin/prmd
@@ -46,7 +46,7 @@ global.order!
 command = ARGV.shift.to_sym
 option = commands[command]
 
-if ARGV.empty?
+if ARGV.empty? && $stdin.tty?
   puts option
   exit(1)
 end
@@ -65,17 +65,26 @@ case command
   when :doc
     Prmd.doc(ARGV[0])
   when :init
-   Prmd.init(ARGV[0], ARGV[1])
+    Prmd.init(ARGV[0], ARGV[1])
   when :verify
-    if File.directory?(ARGV[0])
+    errors = []
+    if ARGV.empty?
+      data = $stdin.read
+      errors = Prmd.verify(JSON.parse(data))
+      puts data
+    elsif File.directory?(ARGV[0])
       Dir.glob(File.join(ARGV[0], '**/*.json')).each do |path|
-        puts(path)
-        Prmd.verify(JSON.parse(File.read(path)))
-        puts
+        Prmd.verify(JSON.parse(File.read(path))).each do |error|
+          errors << "#{path}: #{error}"
+        end
       end
     else
-      Prmd.verify(
-        JSON.parse(File.read(ARGV[0]))
-      )
+      Prmd.verify(JSON.parse(File.read(ARGV[0]))).each do |error|
+        errors << "#{ARGV[0]}: #{error}"
+      end
     end
+    errors.each do |error|
+      $stderr.puts error
+    end
+    exit(1) unless errors.empty?
 end

--- a/lib/prmd/commands/verify.rb
+++ b/lib/prmd/commands/verify.rb
@@ -47,10 +47,6 @@ module Prmd
       end
     end
 
-    if errors.empty?
-      puts("\e[32mNo schema errors detected.\e[0m")
-    else
-      $stderr.puts("\e[31mErrors:\n#{errors.join("\n")}\e[0m")
-    end
+    errors
   end
 end


### PR DESCRIPTION
I would like to make `prmd` more versatile, if you like it, I will expand the idea to the other commands.

This allow to pipe data in and out of the verify command, ensuring that errors are outputted on stderr.

For example:

```
prmd verify < schema.json 2> errors
```

This also improve error formatting, by displaying file path along with errors,
allowing to filter errors per file easily.

For example:

```
prmd verify schema/ |& grep account
```

This will also allow to use `Prmd.verify()` outside of the cli.
