### PR TITLE
Simplify combine command

### DIFF
--- a/bin/prmd
+++ b/bin/prmd
@@ -7,6 +7,9 @@ options = {}
 commands = {
   combine: OptionParser.new do |opts|
     opts.banner = "prmd combine [options] <directory>"
+    opts.on("-o", "--output [file]", "Write output to <file> instead of stdout") do |o|
+      options[:output] = o
+    end
   end,
   doc: OptionParser.new do |opts|
     opts.banner = "prmd doc [options] <directory>"
@@ -46,7 +49,14 @@ option.order!
 
 case command
   when :combine
-    Prmd.combine(ARGV[0])
+    schema = Prmd.combine(ARGV[0])
+    if (path = options[:output])
+      File.open(path, 'w') do |f|
+        f.write(schema.to_s)
+      end
+    else
+      puts schema.to_s
+    end
   when :doc
     Prmd.doc(ARGV[0])
   when :init

--- a/lib/prmd/commands/combine.rb
+++ b/lib/prmd/commands/combine.rb
@@ -1,13 +1,5 @@
 module Prmd
   def self.combine(directory)
-    new_schema = Prmd::Schema.load(directory).to_s
-    old_schema = File.read('schema.json')
-    Diff::LCS.diff(old_schema.split("\n"), new_schema.split("\n")).each do |diff|
-      $stderr.puts("#{diff.first.position}..#{diff.last.position}")
-      diff.each do |change|
-        $stderr.puts("#{change.action} #{change.element}")
-      end
-    end
-    puts new_schema
+    return Prmd::Schema.load(directory)
   end
 end


### PR DESCRIPTION
This is the same idea as #24, applied to combine. I start with the easy parts.

This allow to use `Prmd.combine` outside of the cli, it makes less assumption on
where file suppose to be or where they should be written.

This also allow to pipe prmd commands:

```
prmd combine schema/ | prmd verify
```

And have more flexibility on output:

```
prmd combine -o schema.json schema/
```

And you can still diff the file using diff tools:

```
prmd combine schema/ | diff schema.json -
```
