### PR TITLE
Check if example property exists

### DIFF
--- a/lib/prmd/commands/doc.rb
+++ b/lib/prmd/commands/doc.rb
@@ -89,7 +89,7 @@ module Prmd
             end
           end
         end
-      else
+      elsif definition['example']
         serialization.merge!(definition['example'])
       end
 


### PR DESCRIPTION
The `example` property is not required, but still expected, generating
this kind of error:

```
prmd/lib/prmd/commands/doc.rb:94:in `merge!': no implicit conversion of nil into Hash (TypeError)
```
