### PR TITLE
`prmd init` `prmd verify`s

### DIFF
--- a/lib/prmd/commands/init.rb
+++ b/lib/prmd/commands/init.rb
@@ -3,6 +3,7 @@ module Prmd
     data = {
       '$schema'     => 'http://json-schema.org/draft-04/hyper-schema',
       'title'       => 'FIXME',
+      'description' => 'FIXME',
       'type'        => ['object'],
       'definitions' => {},
       'links'       => [],


### PR DESCRIPTION
Currently a schema that is bootstrapped with `prmd init` doesn't
pass `prmd verify`ication:

``` console
$ git rev-parse HEAD
b4113feedf6fc504b315ed9ed2d1d69eb05fc54c

$ bundle exec bin/prmd init feel > ~/feel.json

$ bundle exec bin/prmd verify ~/feel.json
/Users/mmcgrana/feel.json: Missing `schema/feel#/description`
```

I think it would be nice if this did work. Would you be open to adding
a placeholder description in `init`'d schemas to achieve this?
