### PR TITLE
allow recursive dereferencing

### DIFF
--- a/lib/prmd/schema.rb
+++ b/lib/prmd/schema.rb
@@ -89,7 +89,7 @@ module Prmd
         key.gsub(%r{[^#]*#/}, '').split('/').each do |fragment|
           datum = datum[fragment]
         end
-        datum
+        dereference(datum)
       rescue => error
         $stderr.puts("Failed to dereference `#{key}`")
         raise(error)


### PR DESCRIPTION
I had an error in the `doc_type` method because the given dereferenced property was in fact itself a reference to another definition.

This simple change allows recursive dereferencing and fixes the issue.
