### PR TITLE
Gracefully omit the meta file from schema fragments

### DIFF
--- a/lib/prmd/commands/combine.rb
+++ b/lib/prmd/commands/combine.rb
@@ -1,7 +1,7 @@
 module Prmd
   def self.combine(path, options={})
     files = if File.directory?(path)
-      Dir.glob(File.join(path, '**', '*.json'))
+      Dir.glob(File.join(path, '**', '*.json')) - [options[:meta]]
     else
       [path]
     end


### PR DESCRIPTION
If the meta.json file is in the same directory as schema fragments,
it can currently get double-combined on `prmd combine`: once from the
--meta option and once from being in the given directory. As a
workaround users need to move meta.json out of the schema folder. This
change removes the need to use that workaround if users want the file
in the same directory.
