### PR TITLE
provide guidance on directory structure/location

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,21 @@ You can also chain commands as needed:
 $ prmd combine <directory> | prmd verify | prmd doc > schema.md
 ```
 
+## File Layout
+
+We suggest the following file layout for JSON schema related files:
+
+```
+/docs (top-level directory for project documentation)
+  /schema (API schema documentation)
+    /schemata
+      /{resource.json} (individual resource schema)
+    /meta.json (overall API metadata)
+    /overview.md (preamble for generated API docs)
+    /schema.json (complete generated JSON schema file)
+    /schema.md (complete generated API documentation file)
+```
+
 ## Contributing
 
 1. Fork it


### PR DESCRIPTION
This provides a couple key benefits:
1. Better interop, as you'll be able instantly to find the this in any participating project.
2. Defaulted args, ie could use meta automagically if it followed convention.

Suggestion:
- /schema
  - /schemata
    - {resource}.json (individual resource schema)
    - ...
  - meta.json (required, provides root url and defaults for init)
  - overview.md (optional, prepended to docs)
  - schema.json (optional, combine output)
  - schema.md (optional, doc output)
