### PR TITLE
add --endpoint-template and --parameters-template to doc command

### DIFF
--- a/bin/prmd
+++ b/bin/prmd
@@ -16,6 +16,12 @@ commands = {
     opts.on("-p", "--prepend header,overview", Array, "Prepend files to output") do |p|
       options[:prepend] = p
     end
+    opts.on("--endpoint-template=path", "Path to endpoint template file") do |path|
+      options[:endpoint] = path
+    end
+    opts.on("--parameters-template=path", "Path to parameter template file") do |path|
+      options[:parameters] = path
+    end
   end,
   init: OptionParser.new do |opts|
     opts.banner = "prmd init [options] <resource name>"

--- a/lib/prmd/commands/doc.rb
+++ b/lib/prmd/commands/doc.rb
@@ -99,7 +99,10 @@ module Prmd
 
       title = definition['title'].split(' - ', 2).last
 
-      Erubis::Eruby.new(File.read(File.dirname(__FILE__) + "/../views/endpoint.erb")).result({
+      endpoint = File.read(options[:endpoint] || File.dirname(__FILE__) + "/../views/endpoint.erb")
+      parameters = File.read(options[:parameters] || File.dirname(__FILE__) + "/../views/parameters.erb")
+
+      Erubis::Eruby.new(endpoint).result({
         definition:      definition,
         identifiers:     identifiers,
         resource:        resource,
@@ -107,7 +110,7 @@ module Prmd
         schema:          schema,
         serialization:   serialization,
         title:           title,
-        params_template: File.read(File.dirname(__FILE__) + "/../views/parameters.erb"),
+        params_template: parameters,
       }) + "\n"
     end
   end


### PR DESCRIPTION
These options might be useful for extending output of `doc` subcommand.

Many parameters are passed to `views/endpoint.erb` so we can extend its output flexibly without adding changes to prmd.
