### PR TITLE
fix Gemfile.lock for v0.1.1 release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    prmd (0.1.0)
+    prmd (0.1.1)
       erubis (~> 2.7)
 
 GEM


### PR DESCRIPTION
CI on Travis CI has been failed since https://travis-ci.org/heroku/prmd/builds/23218309 because Gemfile.lock still looks up v0.1.0.
