### PR TITLE
fix --prepend option of the render command causes NoMethodError

### DIFF
--- a/lib/prmd/commands/render.rb
+++ b/lib/prmd/commands/render.rb
@@ -3,7 +3,7 @@ module Prmd
     doc = ''
 
     if options[:prepend]
-      doc << options.prepend.map {|path| File.read(path)}.join("\n") << "\n"
+      doc << options[:prepend].map {|path| File.read(path)}.join("\n") << "\n"
     end
 
     doc << schema['properties'].map do |_, property|


### PR DESCRIPTION
```
/path/to/prmd/commands/render.rb:6:in `render': undefined method `prepend' for {:prepend=>["head"], :template=>"./templates/schemata.erb"}:Hash (NoMethodError)
```
