### PR TITLE
extract building example part of schemata_example() as build_example()

### DIFF
--- a/lib/prmd/schema.rb
+++ b/lib/prmd/schema.rb
@@ -56,7 +56,7 @@ module Prmd
       end
     end
 
-    def build_example(properties)
+    def properties_example(properties)
       example = {}
 
       properties.each do |key, value|
@@ -79,7 +79,7 @@ module Prmd
       @schemata_examples[schemata_id] ||= begin
         example = {}
         if definition['properties']
-          example = build_example(definition['properties'])
+          example = properties_example(definition['properties'])
         else
           example.merge!(definition['example'])
         end


### PR DESCRIPTION
it might be useful for describe some JSON examples in render command (e.g. generate JSON request body by `link['schema']['properties']` value)
