### PR TITLE
fixed errors (unnecessary end keyword and calling schema_example from the template is wrong) of 03ee10c341

### DIFF
--- a/lib/prmd/templates/schemata.erb
+++ b/lib/prmd/templates/schemata.erb
@@ -132,8 +132,7 @@
     path = path.gsub(/{([^}]*)}/) {|match| '$' + match.gsub(/[{}]/, '').upcase}
 
     if link.has_key?('schema')
-      data.merge!(schema_example(link['schema']))
-    end
+      data.merge!(schema.schema_example(link['schema']))
 
       if link['method'].upcase == 'GET' && !data.empty?
         path << '?'


### PR DESCRIPTION
03ee10c341 introduces some errors on default template.
- it has unnecessary end keyword (it outputs error the following: `(erubis:172: syntax error, unexpected keyword_end, expecting end-of-input (SyntaxError)`)
- calling schema_example does not make sense here. it should be schema.schema_example

This pull request is for fix these problems.
