### PR TITLE
fix Gemfile.lock for v0.3.2 release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    prmd (0.3.1)
+    prmd (0.3.2)
       erubis (~> 2.7)
 
 GEM


### PR DESCRIPTION
same an issue as #95. Travis CI always fails again.
