### PR TITLE
Meta-schema improvements

### DIFF
--- a/schemas/interagent-hyper-schema.json
+++ b/schemas/interagent-hyper-schema.json
@@ -9,16 +9,24 @@
     ],
     "definitions": {
         "identity": {
-            "additionalProperties": false,
-            "properties": {
-                "anyOf": {
-                    "additionalProperties": {
-                        "$ref": "#/definitions/ref"
+            "anyOf": [
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "anyOf": {
+                            "additionalProperties": {
+                                "$ref": "#/definitions/ref"
+                            },
+                            "minProperties": 1
+                        }
                     },
-                    "minProperties": 1
+                    "required": ["anyOf"]
+                },
+                {
+                    "properties": {},
+                    "strictProperties": true
                 }
-            },
-            "required": ["anyOf"]
+            ]
         },
         "link": {
             "properties": {


### PR DESCRIPTION
- Forces link hrefs to match our format of an absolute path beginning with a "/" and only containing lowercase letters and hyphens _unless_ the clause is a JSON reference.
  
  ```
  ../api/docs/v3/schema.json: #/definitions/config-var/links/0/href: failed schema #/definitions/link/properties/href: Expected string to match pattern "/^(\/([a-z][a-z-]*[a-z]|{(.*)}))+$/", value was: /apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/config_vars.
  ```
- Forces resource properties (i.e. like `name` on `app`) to use only lowercase letters and underscores.
  
  ```
  ../api/docs/v3/schema.json: #/definitions/domain/properties: failed schema #/definitions/resource/properties/properties: Extra keys in object: created-at.
  ```
- Mandates that resource properties are either references (for a basic property like `name` under `app`) to definitions or a subobject themselves (for say `owner` under `app`).
  
  ```
  ../api/docs/v3/schema.json: #/definitions/domain/properties/hostname: failed schema #/definitions/resource/properties/properties/patternProperties/^[a-z][a-z_]*[a-z]$: Data did not match any subschema of "anyOf" condition.
  ```
- Forces all resources to define `strictProperties` to `true` (and all subschemas contained in `properties` too).
  
  ```
  ../api/docs/v3/schema.json: #/definitions/account-feature/strictProperties: failed schema #/definitions/resource/properties/strictProperties: Expected data to be a member of enum [true], value was: false.
  ```

/cc @geemus @heroku/api
