### PR TITLE
Report the resource that raised an error in `prmd doc`

### DIFF
--- a/lib/prmd/templates/schema.erb
+++ b/lib/prmd/templates/schema.erb
@@ -2,12 +2,17 @@
   schemata_template = Prmd::Template::load('schemata.erb', options[:template])
 
   schema['properties'].map do |resource, property|
-    _, schemata = schema.dereference(property)
-    Erubis::Eruby.new(schemata_template).result({
-      options:         options,
-      resource:        resource,
-      schema:          schema,
-      schemata:        schemata
-    })
+    begin
+      _, schemata = schema.dereference(property)
+      Erubis::Eruby.new(schemata_template).result({
+        options:         options,
+        resource:        resource,
+        schema:          schema,
+        schemata:        schemata
+      })
+    rescue => e 
+      $stdout.puts("Error in resource: #{resource}")
+      raise e
+    end
   end.join("\n") << "\n"
 %>


### PR DESCRIPTION
Adds the second line of output below when prmd doc blows up

```
Failed to dereference `#/definitions%organization-app/definitions/identity`
Error in resource: organization-app-collaborator
```
