### PR TITLE
Use json syntax instead of javascript.

### DIFF
--- a/lib/prmd/templates/schemata/link.erb
+++ b/lib/prmd/templates/schemata/link.erb
@@ -47,7 +47,7 @@ HTTP/1.1 <%= case link['rel']
     '200 OK'
   end %>
 ```
-```javascript```
+```json
   <%- if link['rel'] == 'instances' %>
 <%= JSON.pretty_generate([schema.schemata_example(resource)]) %>
   <%- else %>


### PR DESCRIPTION
Not sure if there was a decision about this, but I think it makes sense to use the `json` type instead of `javascript`. This has the benefit automatically taking advantage of syntax highlighting in GitHub.
