### PR TITLE
Allow content-type to be specified.

### DIFF
--- a/bin/prmd
+++ b/bin/prmd
@@ -16,6 +16,9 @@ commands = {
     opts.on("-p", "--prepend header,overview", Array, "Prepend files to output") do |p|
       options[:prepend] = p
     end
+    opts.on("-c", "--content-type application/json", String, "Content-Type header") do |c|
+      options[:content_type] = c
+    end
   end,
   init: OptionParser.new do |opts|
     opts.banner = "prmd init [options] <resource name>"

--- a/lib/prmd/commands/render.rb
+++ b/lib/prmd/commands/render.rb
@@ -2,6 +2,8 @@ module Prmd
   def self.render(schema, options={})
     doc = ''
 
+    options[:content_type] ||= 'application/json'
+
     if options[:prepend]
       doc << options[:prepend].map {|path| File.read(path)}.join("\n") << "\n"
     end

--- a/lib/prmd/templates/schemata/link_curl_example.erb
+++ b/lib/prmd/templates/schemata/link_curl_example.erb
@@ -19,7 +19,7 @@
   %>
 $ curl -n -X <%= link['method'] %> <%= schema.href %><%= path %>
   <%- unless data.empty? || link['method'].upcase == 'GET' %>
--H "Content-Type: application/json" \
+-H "Content-Type: <%= options[:content_type] %>" \
 -d '<%= data.to_json %>'
   <%- end %>
 ```


### PR DESCRIPTION
Useful if you version your api via the `Content-Type` header.

**Example**

``` bash
$ prmd doc -c 'application/vnd.api+json; version=1' schema.json > schema.md
```
