### PR TITLE
List the defaults in documentation

### DIFF
--- a/lib/prmd/templates/schemata/helper.erb
+++ b/lib/prmd/templates/schemata/helper.erb
@@ -50,6 +50,10 @@
       # just a regular attribute
       else
         description = value['description']
+        if value['default']
+          description += "<br/><b>default:</b> <code>#{value['default'].to_json}</code>"
+        end
+
         if value['enum']
           description += '<br/><b>one of:</b>' + [*value['enum']].map { |e| "<code>#{e.to_json}</code>" }.join(" or ")
         end


### PR DESCRIPTION
Very simple change to allow displaying of defaults in documentation
### JSON schema

``` JSON
"order": {
  "description": "Sort ascending or descending",
  "example": "desc",
  "default": "desc",
  "enum": ["asc", "desc"],
  "type": "string"
},
```
### Before

<table>
  <tr>
    <th>Name</th>
    <th>Type</th>
    <th>Description</th>
    <th>Example</th>
  </tr>
  <tr>
    <td><strong>order</strong></td>
    <td><em>string</em></td>
    <td>Sort ascending or descending<br/><b>one of:</b><code>"asc"</code> or <code>"desc"</code></td>
    <td><code>"desc"</code></td>
  </tr>
</table>

### Now

<table>
  <tr>
    <th>Name</th>
    <th>Type</th>
    <th>Description</th>
    <th>Example</th>
  </tr>
  <tr>
    <td><strong>order</strong></td>
    <td><em>string</em></td>
    <td>Sort ascending or descending<br/><b>default:</b> <code>"desc"</code><br/><b>one of:</b><code>"asc"</code> or <code>"desc"</code></td>
    <td><code>"desc"</code></td>
  </tr>
</table>
