### PR TITLE
Fix incorrect markdown rendering on Github

### DIFF
--- a/lib/prmd/templates/schemata/link_curl_example.erb
+++ b/lib/prmd/templates/schemata/link_curl_example.erb
@@ -19,4 +19,5 @@ $ curl -n -X <%= link['method'] %> <%= schema.href %><%= path -%>
 <%- elsif !get_params.empty? && link['method'].upcase == 'GET' %> -G \
   -d <%= get_params.join(" \\\n  -d ") %>
 <%- end %>
+
 ```


### PR DESCRIPTION
This extremely simple PR fixes incorrect markdown rendering of Curl Example templates on github.

**Current Markdown**

---

![](https://i.cloudup.com/_tsTjU5oL0.png)

**Expected Markdown**

---

![](https://i.cloudup.com/jn3ax1HUdS.png)
