### PR TITLE
[fix] schema initialization id to match docs/schemata.md#meta-data spec

### DIFF
--- a/lib/prmd/commands/init.rb
+++ b/lib/prmd/commands/init.rb
@@ -16,7 +16,7 @@ module Prmd
       if resource.include?('/')
         parent, resource = resource.split('/')
       end
-      schema['id']    = "schemata/#{resource}"
+      schema['id']    = "schema/#{resource}"
       schema['title'] = "FIXME - #{resource[0...1].upcase}#{resource[1..-1]}"
       schema['definitions'] = {
         "created_at" => {


### PR DESCRIPTION
According to https://github.com/interagent/prmd/blob/master/docs/schemata.md#meta-data:
- `id` - an id for this schema, it MUST be in the form `"schema/#{lower_case_singular_resource}"`

Currently `prmd init` generates `schemata/XXX` instead of `schema/XXX`, behaviour corrected in this PR. 

If I am mistaken I can correct `schemata.md` and this PR should be rejected.

Thanks
