### PR TITLE
- Patterns often contain '|' which conflicts with most Markdown->HTML code

### DIFF
--- a/lib/prmd/templates/schemata/helper.erb
+++ b/lib/prmd/templates/schemata/helper.erb
@@ -86,7 +86,7 @@
     end
 
     if value['pattern']
-      description += "<br/><b>pattern: </b><code>#{value['pattern']}</code>"
+      description += "<br/> **pattern:** <code>#{value['pattern'].gsub /\|/, '&#124;'}</code>"
     end
 
     if value.has_key?('example')


### PR DESCRIPTION
Unless this character is replaced, it causes the table to get split up mid-cell.  The current "suggested" workaround is to use the HTML symbol for '|' until this gets fixed (https://github.com/gitlabhq/gitlabhq/issues/1238).  Unfortunately, that means we also need to use <code> tags as ` causes the symbol to be printed as plain-text &#124;.
