### PR TITLE
Hide headers (via settings)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Available options (and their defaults)
 {
   "doc": {
     "url_style": "default", // can also be "json"
-    "disable_headers": false // remove the header and the description, useful when using your own custom header
+    "disable_title_and_description": false // remove the title and the description, useful when using your own custom header
   }
 }
 ```

--- a/lib/prmd/commands/render.rb
+++ b/lib/prmd/commands/render.rb
@@ -4,7 +4,7 @@ module Prmd
     options[:content_type] ||= 'application/json'
     options[:doc] ||= {}
     options[:doc][:url_style] ||= 'default'
-    options[:doc][:disable_headers] ||= false
+    options[:doc][:disable_title_and_description] ||= false
 
     if options[:prepend]
       doc << options[:prepend].map {|path| File.read(path)}.join("\n") << "\n"

--- a/lib/prmd/templates/schemata.erb
+++ b/lib/prmd/templates/schemata.erb
@@ -10,7 +10,7 @@
 
   title = schemata['title'].split(' - ', 2).last
 -%>
-<%- unless options[:doc][:disable_headers] %>
+<%- unless options[:doc][:disable_title_and_description] %>
 ## <%= title %>
 <%= schemata['description'] %>
 <%- end -%>


### PR DESCRIPTION
For my use case I am breaking out all of my resources into their own markdown file.
This allows me to give a bigger, more detailed description of the endpoint and allows me to link to other pages of documentation with examples.

For this I need to be able to remove the generated headers & descriptions (as I am doing that myself already).

This pull requests adds documentation on how to remove the headers and adds to functionality to do so as well.

See the modified README.md file for more information.
