### PR TITLE
Remove additional spaces from link properties markdown

### DIFF
--- a/lib/prmd/templates/link_schema_properties.erb
+++ b/lib/prmd/templates/link_schema_properties.erb
@@ -1,5 +1,5 @@
-  | Name | Type | Description | Example |
-  | ------- | ------- | ------- | ------- |
-  <%- extract_attributes(schema, params).each do |(key, type, description, example)| %>
-  | **<%= key %>** | *<%= type %>* | <%= description %> | <%= example %> |
-  <%- end %>
+| Name | Type | Description | Example |
+| ------- | ------- | ------- | ------- |
+<%- extract_attributes(schema, params).each do |(key, type, description, example)| %>
+| **<%= key %>** | *<%= type %>* | <%= description %> | <%= example %> |
+<%- end %>


### PR DESCRIPTION
Github markdown can't draw table if there are spaces before first pipe symbol
