### PR TITLE
Add better error checking

### DIFF
--- a/lib/prmd/cli.rb
+++ b/lib/prmd/cli.rb
@@ -73,7 +73,7 @@ module Prmd
       abort parser unless commands.include?(command)
       options[:argv] = com_argv
       options[:command] = command
-      options
+      [options, parser]
     end
 
     # Execute the Prmd CLI, or its subcommands
@@ -82,21 +82,21 @@ module Prmd
     # @param [Hash<Symbol, Object>] opts
     # @return [void]
     def self.run(uargv, opts = {})
-      options = parse_options(uargv, opts)
+      options, parser = parse_options(uargv, opts)
       argv = options.delete(:argv)
       command = options.delete(:command)
 
       case command
       when :combine
-        CLI::Combine.run(argv, options)
+        CLI::Combine.run(argv, options, parser)
       when :doc
-        CLI::Doc.run(argv, options)
+        CLI::Doc.run(argv, options, parser)
       when :init
-        CLI::Generate.run(argv, options)
+        CLI::Generate.run(argv, options, parser)
       when :render
-        CLI::Render.run(argv, options)
+        CLI::Render.run(argv, options, parser)
       when :verify
-        CLI::Verify.run(argv, options)
+        CLI::Verify.run(argv, options, parser)
       end
     end
 

--- a/lib/prmd/cli/base.rb
+++ b/lib/prmd/cli/base.rb
@@ -110,7 +110,7 @@ module Prmd
       # @param [Hash<Symbol, Object>] options
       # @return [void]
       # @abstract
-      def execute(options = {})
+      def execute(options = {}, parser)
         #
       end
 
@@ -119,7 +119,7 @@ module Prmd
       #
       # @param [Hash<Symbol, Object>] options
       # @return [void]
-      def noop_execute(options = {})
+      def noop_execute(options = {}, parser)
         $stderr.puts options
       end
 
@@ -133,12 +133,12 @@ module Prmd
       # @param [Array<String>] argv
       # @param [Hash<Symbol, Object>] options
       # @return [void]
-      def run(argv, options = {})
+      def run(argv, options = {}, parser)
         options = options.merge(parse_options(argv, options))
         if options[:noop]
-          noop_execute(options)
+          noop_execute(options, parser)
         else
-          execute(options)
+          execute(options, parser)
         end
       end
 

--- a/lib/prmd/cli/combine.rb
+++ b/lib/prmd/cli/combine.rb
@@ -34,7 +34,9 @@ module Prmd
       #
       # @param (see Prmd::CLI::Base#execute)
       # @return (see Prmd::CLI::Base#execute)
-      def self.execute(options = {})
+      def self.execute(options = {}, parser)
+        filename = options.fetch(:argv).first
+        abort parser if filename.nil? || filename.empty?
         write_result Prmd.combine(options[:argv], options).to_s, options
       end
     end

--- a/lib/prmd/cli/doc.rb
+++ b/lib/prmd/cli/doc.rb
@@ -56,8 +56,9 @@ module Prmd
       #
       # @param (see Prmd::CLI::Base#execute)
       # @return (see Prmd::CLI::Base#execute)
-      def self.execute(options = {})
+      def self.execute(options = {}, parser)
         filename = options.fetch(:argv).first
+        abort parser if filename.nil? || filename.empty?
         template = File.expand_path('templates', File.dirname(__FILE__))
         _, data = try_read(filename)
         schema = Prmd::Schema.new(data)

--- a/lib/prmd/cli/generate.rb
+++ b/lib/prmd/cli/generate.rb
@@ -35,8 +35,9 @@ module Prmd
       #
       # @param (see Prmd::CLI::Base#execute)
       # @return (see Prmd::CLI::Base#execute)
-      def self.execute(options = {})
+      def self.execute(options = {}, parser)
         name = options.fetch(:argv).first
+        abort parser if name.nil? || name.empty?
         write_result Prmd.init(name, options), options
       end
     end

--- a/lib/prmd/cli/render.rb
+++ b/lib/prmd/cli/render.rb
@@ -37,8 +37,10 @@ module Prmd
       #
       # @param (see Prmd::CLI::Base#execute)
       # @return (see Prmd::CLI::Base#execute)
-      def self.execute(options = {})
+      def self.execute(options = {}, parser)
         filename = options.fetch(:argv).first
+        abort parser if filename.nil? || filename.empty?
+
         _, data = try_read(filename)
         schema = Prmd::Schema.new(data)
         write_result Prmd.render(schema, options), options

--- a/lib/prmd/cli/verify.rb
+++ b/lib/prmd/cli/verify.rb
@@ -32,8 +32,9 @@ module Prmd
       #
       # @param (see Prmd::CLI::Base#execute)
       # @return (see Prmd::CLI::Base#execute)
-      def self.execute(options = {})
+      def self.execute(options = {}, parser)
         filename = options.fetch(:argv).first
+        abort parser if filename.nil? || filename.empty?
         _, data = try_read(filename)
         errors = Prmd.verify(data)
         unless errors.empty?

--- a/lib/prmd/commands/combine.rb
+++ b/lib/prmd/commands/combine.rb
@@ -80,6 +80,7 @@ module Prmd
       schema = base['$schema']
       meta = {}
       meta = Prmd.load_schema_file(options[:meta]) if options[:meta]
+      abort "Loading meta file failed" if meta.nil? && options[:meta]
       combiner = Prmd::Combiner.new(meta: meta, base: base, schema: schema)
       combiner.combine(*schemata)
     end

--- a/lib/prmd/load_schema_file.rb
+++ b/lib/prmd/load_schema_file.rb
@@ -13,13 +13,15 @@ module Prmd
     File.open(filename) do |file|
       case extname.downcase
       when '.yaml', '.yml'
-        YAML.load(file.read)
+        result = YAML.load(file.read)
       when '.json'
-        JSON.load(file.read)
+        result = JSON.load(file.read)
       else
         abort "Cannot load schema file #{filename}" \
               "(unsupported file extension #{extname})"
       end
+      abort "Cannot parse schema file #{filename}" if result.nil?
+      result
     end
   end
 end


### PR DESCRIPTION
I am on `jruby-1.7.16-d19` with prmd `0.6.2` at `d2897` and my rake tasks fail to run:
```
$ rake schema --trace
** Invoke schema (first_time)
** Invoke schema:combine (first_time)
** Execute schema:combine
rake aborted!
TypeError: can't convert nil into Hash
org/jruby/RubyHash.java:1737:in `merge!'
/home/rx14/.rvm/gems/jruby-1.7.16-d19@satapi/bundler/gems/prmd-d28977070dcb/lib/prmd/core/combiner.rb:61:in `combine'
/home/rx14/.rvm/gems/jruby-1.7.16-d19@satapi/bundler/gems/prmd-d28977070dcb/lib/prmd/commands/combine.rb:84:in `combine'
/home/rx14/.rvm/gems/jruby-1.7.16-d19@satapi/bundler/gems/prmd-d28977070dcb/lib/prmd/commands/combine.rb:98:in `combine'
/home/rx14/.rvm/gems/jruby-1.7.16-d19@satapi/bundler/gems/prmd-d28977070dcb/lib/prmd/rake_tasks/combine.rb:40:in `define'
org/jruby/RubyProc.java:271:in `call'
/home/rx14/.rvm/gems/jruby-1.7.16-d19@satapi/gems/rake-10.3.2/lib/rake/task.rb:240:in `execute'
org/jruby/RubyArray.java:1613:in `each'
/home/rx14/.rvm/gems/jruby-1.7.16-d19@satapi/gems/rake-10.3.2/lib/rake/task.rb:235:in `execute'
/home/rx14/.rvm/gems/jruby-1.7.16-d19@satapi/gems/rake-10.3.2/lib/rake/task.rb:179:in `invoke_with_call_chain'
/home/rx14/.rvm/rubies/jruby-1.7.16-d19/lib/ruby/2.0/monitor.rb:211:in `mon_synchronize'
/home/rx14/.rvm/gems/jruby-1.7.16-d19@satapi/gems/rake-10.3.2/lib/rake/task.rb:172:in `invoke_with_call_chain'
/home/rx14/.rvm/gems/jruby-1.7.16-d19@satapi/gems/rake-10.3.2/lib/rake/task.rb:201:in `invoke_prerequisites'
org/jruby/RubyArray.java:1613:in `each'
/home/rx14/.rvm/gems/jruby-1.7.16-d19@satapi/gems/rake-10.3.2/lib/rake/task.rb:199:in `invoke_prerequisites'
/home/rx14/.rvm/gems/jruby-1.7.16-d19@satapi/gems/rake-10.3.2/lib/rake/task.rb:178:in `invoke_with_call_chain'
/home/rx14/.rvm/rubies/jruby-1.7.16-d19/lib/ruby/2.0/monitor.rb:211:in `mon_synchronize'
/home/rx14/.rvm/gems/jruby-1.7.16-d19@satapi/gems/rake-10.3.2/lib/rake/task.rb:172:in `invoke_with_call_chain'
/home/rx14/.rvm/gems/jruby-1.7.16-d19@satapi/gems/rake-10.3.2/lib/rake/task.rb:165:in `invoke'
/home/rx14/.rvm/gems/jruby-1.7.16-d19@satapi/gems/rake-10.3.2/lib/rake/application.rb:150:in `invoke_task'
/home/rx14/.rvm/gems/jruby-1.7.16-d19@satapi/gems/rake-10.3.2/lib/rake/application.rb:106:in `top_level'
org/jruby/RubyArray.java:1613:in `each'
/home/rx14/.rvm/gems/jruby-1.7.16-d19@satapi/gems/rake-10.3.2/lib/rake/application.rb:106:in `top_level'
/home/rx14/.rvm/gems/jruby-1.7.16-d19@satapi/gems/rake-10.3.2/lib/rake/application.rb:115:in `run_with_threads'
/home/rx14/.rvm/gems/jruby-1.7.16-d19@satapi/gems/rake-10.3.2/lib/rake/application.rb:100:in `top_level'
/home/rx14/.rvm/gems/jruby-1.7.16-d19@satapi/gems/rake-10.3.2/lib/rake/application.rb:78:in `run'
/home/rx14/.rvm/gems/jruby-1.7.16-d19@satapi/gems/rake-10.3.2/lib/rake/application.rb:176:in `standard_exception_handling'
/home/rx14/.rvm/gems/jruby-1.7.16-d19@satapi/gems/rake-10.3.2/lib/rake/application.rb:75:in `run'
/home/rx14/.rvm/gems/jruby-1.7.16-d19@satapi/gems/rake-10.3.2/bin/rake:33:in `(root)'
org/jruby/RubyKernel.java:1081:in `load'
/home/rx14/.rvm/gems/jruby-1.7.16-d19@satapi/bin/rake:1:in `(root)'
org/jruby/RubyKernel.java:1101:in `eval'
/home/rx14/.rvm/gems/jruby-1.7.16-d19@satapi/bin/jruby_executable_hooks:15:in `(root)'
Tasks: TOP => schema => schema:combine
```

Rakefile:
```ruby
require "prmd/rake_tasks/combine"
require "prmd/rake_tasks/verify"
require "prmd/rake_tasks/doc"

repo_root = File.absolute_path("#{__dir__}/../../")

namespace :schema do
    Prmd::RakeTasks::Combine.new do |t|
        t.options[:meta] = "#{repo_root}/docs/schema/meta.json"
        t.paths << "#{repo_root}/docs/schema/schemata"
        t.output_file = "#{repo_root}/docs/schema/api.json"
    end

    Prmd::RakeTasks::Verify.new do |t|
        t.files << "#{repo_root}/docs/schema/api.json"
    end

    Prmd::RakeTasks::Doc.new do |t|
        t.files = { "#{repo_root}/docs/schema/api.json" => "#{repo_root}/docs/schema/api.md" }
    end
end

task schema: ["schema:combine", "schema:verify", "schema:doc"]
```

I am quite tired right now from troubleshooting right now so I must go to bed. I will provide more details if required in the morning.