### PR TITLE
Remove sorting in the extract_attributes

### DIFF
--- a/lib/prmd/templates/schemata/helper.erb
+++ b/lib/prmd/templates/schemata/helper.erb
@@ -1,7 +1,6 @@
 <%-
   def extract_attributes(schema, properties)
     attributes = []
-    properties = properties.sort_by {|k,v| k} # ensure consistent ordering
 
     properties.each do |key, value|
       # found a reference to another element:


### PR DESCRIPTION
In default, prmd renders sorted attributes by using `extract_attributes` helper method, but the behavior is inconsistent with `schema_value_example`'s one.

The inconsistent is started since 33a653bccbce9c2f4b1df4aa186cd3cd16a13a39. `schema_value_example` renders no-sorted attributes by the chages, but `extract_attributes` didn't.

I think `extract_attributes` should not sort properties too for the same reason of 33a653bccbce9c2f4b1df4aa186cd3cd16a13a39 changes.
