### PR TITLE
Add spaces to error message

### DIFF
--- a/lib/prmd/core/combiner.rb
+++ b/lib/prmd/core/combiner.rb
@@ -65,8 +65,8 @@ module Prmd
         id_ary = id.split('/').last
 
         if s = schemata_map[id]
-          $stderr.puts "`#{id}` (from #{schema.filename}) was already defined" \
-                       "in `#{s.filename}` and will overwrite the first" \
+          $stderr.puts "`#{id}` (from #{schema.filename}) was already defined " \
+                       "in `#{s.filename}` and will overwrite the first " \
                        "definition"
         end
         # avoinding damaging the original schema


### PR DESCRIPTION
It's a small thing, but it fixes this message:

```
`schemata/baz` (from ./schema/variants/foo/bar/baz.yaml) was already definedin `./schema/schemata/baz.yaml` and will overwrite the firstdefinition
```
