### PR TITLE
Ensure there are spaces after headers and tables

### DIFF
--- a/lib/prmd/templates/schemata.md.erb
+++ b/lib/prmd/templates/schemata.md.erb
@@ -12,16 +12,19 @@
 -%>
 <%- unless options[:doc][:disable_title_and_description] %>
 ## <%= title %>
+
 <%= schemata['description'] %>
 <%- end -%>
 
 <%- if schemata['properties'] && !schemata['properties'].empty? %>
 ### Attributes
+
 | Name | Type | Description | Example |
 | ------- | ------- | ------- | ------- |
 <%- extract_attributes(schema, schemata['properties']).each do |(key, type, description, example)| %>
 | **<%= key %>** | *<%= type %>* | <%= description %> | <%= example %> |
 <%- end %>
+
 <%- end %>
 <%- schemata['links'].each do |link, datum| %>
 <%=

--- a/lib/prmd/templates/schemata/link.md.erb
+++ b/lib/prmd/templates/schemata/link.md.erb
@@ -4,6 +4,7 @@
   link_schema_properties_template = Prmd::Template.load_template('link_schema_properties.md.erb', options[:template])
 -%>
 ### <%= title %> <%= link['title'] %>
+
 <%= link['description'] %>
 
 ```
@@ -18,16 +19,19 @@
   %>
   <%- unless required.empty? %>
 #### Required Parameters
+
 <%= link_schema_properties_template.result(params: required, schema: schema, options: options) %>
 
   <%- end %>
   <%- unless optional.empty? %>
 #### Optional Parameters
+
 <%= link_schema_properties_template.result(params: optional, schema: schema, options: options) %>
   <%- end %>
 <%- end %>
 
 #### Curl Example
+
 <%=
   curl_options = options.dup
   http_header = link['http_header'] || {}
@@ -43,6 +47,7 @@
 %>
 
 #### Response Example
+
 ```
 <%- if response_example %>
 <%=   response_example['head'] %>
@@ -58,6 +63,7 @@ HTTP/1.1 <%=
   end %>
 <%- end %>
 ```
+
 ```json
 <%- if response_example %>
 <%=   response_example['body'] %>

--- a/lib/prmd/templates/schemata/link_curl_example.md.erb
+++ b/lib/prmd/templates/schemata/link_curl_example.md.erb
@@ -25,5 +25,4 @@ $ curl -n -X <%= link['method'] %> <%= schema.href %><%= path -%><%- unless opti
 <%- elsif !get_params.empty? && link['method'].upcase == 'GET' %> -G \
   -d <%= get_params.join(" \\\n  -d ") %>
 <%- end %>
-
 ```


### PR DESCRIPTION
* Headers beginning with #s should have blank lines both
  before and after; add this spacing.
* Add blank lines around tables (for the same reason);
  this closes #189.
* Remove spurious blank line at the ends of curl examples.
* I noticed there are sometimes two blank lines *before* a
  heading; this looks like it may be down to the way the
  templates are coded (I'm a ruby newbie). I think it is
  not a showstopper (and this patch does not affect it).