### PR TITLE
Dereference properties

### DIFF
--- a/lib/prmd/templates/schemata/helper.erb
+++ b/lib/prmd/templates/schemata/helper.erb
@@ -2,6 +2,8 @@
   def extract_attributes(schema, properties)
     attributes = []
 
+    _, properties = schema.dereference(properties)
+
     properties.each do |key, value|
       # found a reference to another element:
       _, value = schema.dereference(value)


### PR DESCRIPTION
Hello. I would like to define object's properties in another file and $ref them in controller's schema but i can't.

Example of schema:

```json
{
  "id": "schemata/api:v2:global_surveys_controller",
  "type": "object",
  "title": "/api/v2/global_surveys",
  "description": "Global surveys controller",
  "properties": {
    "$ref": "/api:v2:global_survey#/definitions/properties"
  },
  "links": [ ]
}
```

`prmd doc` fails with `/home/predator/.rvm/gems/ruby-2.1.4@crowd/bundler/gems/prmd-a65e6fbdd4b0/lib/prmd/templates/schemata/helper.erb:111:in `build_attribute': undefined method `include?' for nil:NilClass (NoMethodError)`