### PR TITLE
render default examples correctly

### DIFF
--- a/lib/prmd/templates/schemata/helper.erb
+++ b/lib/prmd/templates/schemata/helper.erb
@@ -58,7 +58,7 @@
     end
     attributes.map! { |key, type, description, example|
       if example.nil? && Prmd::DefaultExamples.key?(type)
-        example = Prmd::DefaultExamples[type]
+        example = "`%s`" % Prmd::DefaultExamples[type].to_json
       end
       [key, type, description, example]
     }


### PR DESCRIPTION
We forgot to turn them into their JSON representation as well as to mark
them as code in markdown.