### PR TITLE
Link to resources from attributes list

### DIFF
--- a/lib/prmd/templates/schemata.md.erb
+++ b/lib/prmd/templates/schemata.md.erb
@@ -11,7 +11,7 @@
   title = schemata['title'].split(' - ', 2).last
 -%>
 <%- unless options[:doc][:disable_title_and_description] %>
-## <%= title %>
+## <a name="resource-<%= resource %>"></a><%= title %>
 
 <%= schemata['description'] %>
 <%- end -%>
@@ -21,8 +21,14 @@
 
 | Name | Type | Description | Example |
 | ------- | ------- | ------- | ------- |
-<%- extract_attributes(schema, schemata['properties']).each do |(key, type, description, example)| %>
-| **<%= key %>** | *<%= type %>* | <%= description %> | <%= example %> |
+<%- refs = extract_schemata_refs(schema, schemata['properties']).map {|v| v && v.split("/")} %>
+<%- extract_attributes(schema, schemata['properties']).each_with_index do |(key, type, description, example), i| %>
+<%- if refs[i] && refs[i][1] == "definitions" && refs[i][2] != resource %>
+<%- name = '[%s](#%s)' % [key, 'resource-' + refs[i][2]] %>
+<%- else %>
+<%- name = key %>
+<%- end %>
+| **<%= name %>** | *<%= type %>* | <%= description %> | <%= example %> |
 <%- end %>
 
 <%- end %>

--- a/lib/prmd/templates/schemata/helper.erb
+++ b/lib/prmd/templates/schemata/helper.erb
@@ -65,6 +65,38 @@
     return attributes
   end
 
+  def extract_schemata_refs(schema, properties)
+    ret = []
+    properties.each do |_, value|
+      ref, value = schema.dereference(value)
+      if value['properties']
+        refs = extract_schemata_refs(schema, value['properties'])
+      elsif value['items'] && value['items']['properties']
+        refs = extract_schemata_refs(schema, value['items']['properties'])
+      else
+        refs = [ref]
+      end
+      if value.has_key?('type') && value['type'].include?('null') && (value.has_key?('items') || value.has_key?('properties'))
+        # A nullable object usually isn't a reference to another schema. It's
+        # either not a reference at all, or it's a reference within the same
+        # schema. Instead, the definition of the nullable object might contain
+        # references to specific properties.
+        #
+        # If all properties refer to the same schema, we'll use that as the
+        # reference. This might even overwrite an actual, intra-schema
+        # reference.
+
+        l = refs.map {|v| v && v.split("/")[0..2]}
+        if l.uniq.size == 1 && l[0] != nil
+          ref = l[0].join("/")
+        end
+        ret << ref
+      end
+      ret.concat(refs)
+    end
+    ret
+  end
+
   def build_attribute(schema, key, value)
     description = value['description'] || ""
     if value['default']


### PR DESCRIPTION
When a resource's property refers to another resource, create links in
the first resource's attributes list to the second resource.

When a property is a nullable object consisting of properties from other
resources, and if all the properties refer to the same resource, the
nullable object's entry will also link to that resource, even if the
nullable object wasn't a direct reference.

Attached are several examples, generated from Heroku's schema. The last example, for `Organization App` demonstrates what happens when a schema reuses most attributes of another schema. We don't just linkify embedded objects, but all attributes that are defined in another schema. This makes the code simpler and the behaviour more predictable.

![2015-05-23-232221_1013x748_scrot](https://cloud.githubusercontent.com/assets/39825/7785475/0294dcbc-0192-11e5-96bf-a92ccbe78f25.png)
![2015-05-23-232253_968x917_scrot](https://cloud.githubusercontent.com/assets/39825/7785476/02955d18-0192-11e5-9c8c-1bd6b19d053b.png)
![2015-05-23-232318_1868x905_scrot](https://cloud.githubusercontent.com/assets/39825/7785477/0297d426-0192-11e5-8ee4-0306ed8bb071.png)

Closes #217 