### PR TITLE
don't emit empty pre block when there's no response example

### DIFF
--- a/lib/prmd/templates/schemata/link.md.erb
+++ b/lib/prmd/templates/schemata/link.md.erb
@@ -64,6 +64,7 @@ HTTP/1.1 <%=
 <%- end %>
 ```
 
+<%- if response_example || link['rel'] != 'empty' %>
 ```json
 <%- if response_example %>
 <%=   response_example['body'] %>
@@ -78,3 +79,4 @@ HTTP/1.1 <%=
 <%-   end %>
 <%- end %>
 ```
+<%- end %>


### PR DESCRIPTION
This avoids emitting an empty `<pre></pre>` when there's no response example. I'm not sure if the empty `pre` was a deliberate decision (then just ignore my patch) or if it was an oversight. It certainly looks funny when `pre` is styled to stand out.