### PR TITLE
fix test_resource_link_href_format test

### DIFF
--- a/test/commands/verify_test.rb
+++ b/test/commands/verify_test.rb
@@ -107,12 +107,12 @@ class InteragentHyperSchemaVerifyTest < Minitest::Test
 
   def test_resource_link_href_format
     pointer('#/definitions/app/links/0').merge!({
-      'href' => '/my_apps'
+      'href' => '/my~apps'
     })
     errors = verify
     assert_equal 1, errors.count
     assert_match %r{^#/definitions/app/links/0/href: }, errors[0]
-    assert_match /\/my_apps does not match /, errors[0]
+    assert_match /\/my~apps does not match /, errors[0]
   end
 
   def test_resource_link_required


### PR DESCRIPTION
Update `test_resource_link_href_format` test to use invalid character in order to fix broken master.

```
 1) Failure:
InteragentHyperSchemaVerifyTest#test_resource_link_href_format [/home/travis/build/interagent/prmd/test/commands/verify_test.rb:113]:
Expected: 1
  Actual: 0
51 runs, 133 assertions, 1 failures, 0 errors, 0 skips
rake aborted!
Command failed with status (1): [ruby -I"lib" -I"/home/travis/.rvm/gems/ruby-1.9.3-p551/gems/rake-10.4.2/lib" "/home/travis/.rvm/gems/ruby-1.9.3-p551/gems/rake-10.4.2/lib/rake/rake_test_loader.rb" "test/**/*_test.rb" ]
/home/travis/.rvm/gems/ruby-1.9.3-p551/bin/ruby_executable_hooks:15:in `eval'
/home/travis/.rvm/gems/ruby-1.9.3-p551/bin/ruby_executable_hooks:15:in `<main>'
Tasks: TOP => default => test
(See full trace by running task with --trace)
```