### PR TITLE
first pass at adding stub command

### DIFF
--- a/lib/prmd/cli.rb
+++ b/lib/prmd/cli.rb
@@ -3,6 +3,7 @@ require_relative 'cli/combine'
 require_relative 'cli/doc'
 require_relative 'cli/generate'
 require_relative 'cli/render'
+require_relative 'cli/stub'
 require_relative 'cli/verify'
 
 # :nodoc:
@@ -17,6 +18,7 @@ module Prmd
         doc:     CLI::Doc.make_parser(props),
         init:    CLI::Generate.make_parser(props),
         render:  CLI::Render.make_parser(props),
+        stub:    CLI::Stub.make_parser(props),
         verify:  CLI::Verify.make_parser(props)
       }
     end
@@ -95,6 +97,8 @@ module Prmd
         CLI::Generate.run(argv, options)
       when :render
         CLI::Render.run(argv, options)
+      when :stub
+        CLI::Stub.run(argv, options)
       when :verify
         CLI::Verify.run(argv, options)
       end

--- a/lib/prmd/cli/stub.rb
+++ b/lib/prmd/cli/stub.rb
@@ -1,0 +1,45 @@
+require_relative 'base'
+
+module Prmd
+  module CLI
+    # 'stub' command module'
+    module Stub
+      extend CLI::Base
+
+      # Returns a OptionParser for parsing 'stub' command options.
+      #
+      # @param (see Prmd::CLI::Base#make_parser)
+      # @return (see Prmd::CLI::Base#make_parser)
+      def self.make_parser(options = {})
+        binname = options.fetch(:bin, 'prmd')
+
+        OptionParser.new do |opts|
+          opts.banner = "#{binname} stub [options] <combined schema>"
+        end
+      end
+
+      # Executes the 'stub' command.
+      #
+      # @example Usage
+      #   Prmd::CLI::Stub.execute(argv: ['schema/api.json'])
+      #
+      # @param (see Prmd::CLI::Base#execute)
+      # @return (see Prmd::CLI::Base#execute)
+      def self.execute(options = {})
+        require "committee"
+
+        filename = options.fetch(:argv).first
+        _, schema = try_read(filename)
+
+        app = Rack::Builder.new {
+          use Committee::Middleware::RequestValidation, schema: schema
+          use Committee::Middleware::ResponseValidation, schema: schema
+          use Committee::Middleware::Stub, schema: schema
+          run lambda { |_| [404, {}, ["Not found"]] }
+        }
+
+        Rack::Server.start(app: app)
+      end
+    end
+  end
+end


### PR DESCRIPTION
borrowing from the idea of committee-stub

Note, will probably need/want to provide ways to pass in additional config (ie stuff like tolerant mode from committee stub, which doesn't do request/response validation), but this is at least a good start.

Also note that presently you would need to add committee to installed/bundled stuff on your own, to avoid adding it to the gem deps for those that don't need it (though perhaps just adding it isn't too off-base).