### PR TITLE
Add default example for enum type

### DIFF
--- a/lib/prmd/schema.rb
+++ b/lib/prmd/schema.rb
@@ -126,6 +126,8 @@ module Prmd
         else
           [schema_example(items)]
         end
+      elsif value.key?('enum')
+        value['enum'][0]
       elsif DefaultExamples.key?(value["format"])
         DefaultExamples[value["format"]]
       elsif DefaultExamples.key?(value["type"][0])

--- a/lib/prmd/templates/schemata/helper.erb
+++ b/lib/prmd/templates/schemata/helper.erb
@@ -164,7 +164,7 @@
         "`#{value['example'].to_json}`"
       end
     elsif (value['type'] == ['array'] && value.has_key?('items')) || value.has_key?('enum')
-      example = "`#{schema.schema_value_example(value)}`"
+      example = "`#{schema.schema_value_example(value).to_json}`"
     elsif value['type'].include?('null')
       example = "`null`"
     end

--- a/lib/prmd/templates/schemata/helper.erb
+++ b/lib/prmd/templates/schemata/helper.erb
@@ -163,7 +163,7 @@
       else
         "`#{value['example'].to_json}`"
       end
-    elsif value['type'] == ['array'] && value.has_key?('items')
+    elsif (value['type'] == ['array'] && value.has_key?('items')) || value.has_key?('enum')
       example = "`#{schema.schema_value_example(value)}`"
     elsif value['type'].include?('null')
       example = "`null`"


### PR DESCRIPTION
Given this example schema:
```
grant_type:
  description: "Authentication method to use."
  type: "string"
  enum: ["password", "auth_code"]
```
It is obvious that e.g. `password` is a valid value for `grant_type` and can therefore be used as a default example if no `example` key is specified.

Two questions:

* The current default example for strings is displayed as `"password"`. This change however displays them just as `password`. I wasn't quite sure how/where to handle this. `schema_value_example` is the wrong place since that is also used in the CURL example
* The changed `elsif`  in `build_attribute` looks quite ugly now, but I did not want to duplicate the call to `schema_value_example`. Also, I'm not sure that condition actually covers all scenarios where we would want to get the example value (e.g. for `properties`)?
