### PR TITLE
Allow custom init template to be used

### DIFF
--- a/lib/prmd/cli/generate.rb
+++ b/lib/prmd/cli/generate.rb
@@ -18,6 +18,9 @@ module Prmd
 
         OptionParser.new do |opts|
           opts.banner = "#{binname} init [options] <resource name>"
+          opts.on('-t', '--template templates', String, 'Use alternate template') do |t|
+            yield :template, t
+          end
           opts.on('-y', '--yaml', 'Generate YAML') do |y|
             yield :yaml, y
           end

--- a/lib/prmd/commands/init.rb
+++ b/lib/prmd/commands/init.rb
@@ -9,9 +9,21 @@ module Prmd
     # Creates a default Prmd::Generator using default templates
     #
     # @return [Prmd::Generator]
-    def self.make_generator
+    def self.make_generator(options)
       base = Prmd::Template.load_json('init_default.json')
-      template = Prmd::Template.load_template('init_resource.json.erb', '')
+      template_name = options.fetch(:template) do
+        abort 'render: Template was not provided'
+      end
+      if template_name && !template_name.empty?
+        template_dir = File.expand_path(template_name)
+        # to keep backward compatibility
+        template_dir = File.dirname(template_name) unless File.directory?(template_dir)
+        template_name = File.basename(template_name)
+      else
+        template_name = 'init_resource.json.erb'
+        template_dir  = ''
+      end
+      template = Prmd::Template.load_template(template_name, template_dir)
       Prmd::Generator.new(base: base, template: template)
     end
   end
@@ -22,7 +34,7 @@ module Prmd
   # @param [Hash<Symbol, Object>] options
   # @return [String] schema template in YAML (yaml option was enabled) else JSON
   def self.init(resource, options = {})
-    gen = Generate.make_generator
+    gen = Generate.make_generator(template: options[:template])
 
     generator_options = { resource: nil, parent: nil }
     if resource


### PR DESCRIPTION
This modifies the init command to allow users to specify their own init template. We are using json-api so there are a lot of differences between the included PRMD resource template and what we want. If no template is provided it will default to the PRMD template as before.