### PR TITLE
Add option to pass a custom hyper schema to Verify

### DIFF
--- a/lib/prmd/cli/verify.rb
+++ b/lib/prmd/cli/verify.rb
@@ -22,6 +22,9 @@ module Prmd
           opts.on('-o', '--output-file FILENAME', String, 'File to write result to') do |n|
             yield :output_file, n
           end
+          opts.on('-s', '--custom-schema FILENAME', String, 'Path to custom schema') do |n|
+            yield :custom_schema, n
+          end
         end
       end
 
@@ -35,7 +38,8 @@ module Prmd
       def self.execute(options = {})
         filename = options.fetch(:argv).first
         _, data = try_read(filename)
-        errors = Prmd.verify(data)
+        custom_schema = options[:custom_schema]
+        errors = Prmd.verify(data, custom_schema: custom_schema)
         unless errors.empty?
           errors.map! { |error| "#{filename}: #{error}" } if filename
           errors.each { |error| $stderr.puts(error) }

--- a/lib/prmd/commands/verify.rb
+++ b/lib/prmd/commands/verify.rb
@@ -18,12 +18,17 @@ module Prmd
       store = JsonSchema::DocumentStore.new
       SCHEMAS.each do |file|
         file = File.expand_path("../../../../schemas/#{file}", __FILE__)
-        data = JSON.parse(File.read(file))
-        schema = JsonSchema::Parser.new.parse!(data)
-        schema.expand_references!(store: store)
-        store.add_schema(schema)
+        add_schema(store, file)
       end
+      add_schema(store, @custom_schema) unless @custom_schema.nil?
       store
+    end
+
+    def self.add_schema(store, file)
+      data = JSON.parse(File.read(file))
+      schema = JsonSchema::Parser.new.parse!(data)
+      schema.expand_references!(store: store)
+      store.add_schema(schema)
     end
 
     # @return [JsonSchema::DocumentStore]
@@ -70,7 +75,8 @@ module Prmd
     #
     # @param [Hash] schema_data
     # @return [Array<String>] errors from failed verification
-    def self.verify(schema_data)
+    def self.verify(schema_data, custom_schema: nil)
+      @custom_schema = custom_schema
       a = verify_schema(schema_data)
       return a unless a.empty?
       b = verify_parsable(schema_data)
@@ -88,7 +94,7 @@ module Prmd
   end
 
   # (see Prmd::Verification.verify)
-  def self.verify(schema_data)
-    Verification.verify(schema_data)
+  def self.verify(schema_data, custom_schema: nil)
+    Verification.verify(schema_data, custom_schema: custom_schema)
   end
 end


### PR DESCRIPTION
Hi!

For our particular use of prmd we have a custom hyper schema to describe our schema. We've previously forked and modified the `SCHEMAS` constant in `lib/prmd/commands/verify` to add this schema, but it would be nice to be able to pass it in as a command line argument.

This is a draft of what that implementation might look like. Is this something you'd consider adding?