### PR TITLE
Fix `NameError` when generating documentation via Rake task.

### DIFF
--- a/lib/prmd/rake_tasks/doc.rb
+++ b/lib/prmd/rake_tasks/doc.rb
@@ -4,6 +4,7 @@ require 'prmd/load_schema_file'
 require 'prmd/url_generator'
 require 'prmd/template'
 require 'prmd/schema'
+require 'prmd/link'
 
 # :nodoc:
 module Prmd


### PR DESCRIPTION
`NameError: uninitialized constant Prmd::Link` was thrown before when generating
documentation via the included Rake task. Requiring `prmd/link` seems to solve
the issue.

This pull request solves the issue mentioned in https://github.com/interagent/prmd/issues/263.

The build is failing, but it appears to be unrelated to this pull request.

CC: @geemus.