### PR TITLE
Allow header OR body overwrite in response md

### DIFF
--- a/lib/prmd/templates/schemata/link.md.erb
+++ b/lib/prmd/templates/schemata/link.md.erb
@@ -47,7 +47,7 @@
 #### Response Example
 
 ```
-<%- if response_example %>
+<%- if response_example.has_key?('head') %>
 <%=   response_example['head'] %>
 <%- else %>
 HTTP/1.1 <%=
@@ -62,9 +62,9 @@ HTTP/1.1 <%=
 <%- end %>
 ```
 
-<%- if response_example || link['rel'] != 'empty' %>
+<%- if response_example.has_key?('body') || link['rel'] != 'empty' %>
 ```json
-<%- if response_example %>
+<%- if response_example.has_key?('body') %>
 <%=   response_example['body'] %>
 <%- else %>
 <%-   if link['rel'] == 'empty' %>


### PR DESCRIPTION
Sorta related to #3. It looks like I can overwrite the mark down template output by setting `response_example` in the JSON schema link.  But I have to overwrite the returned headers AND body.  This would allow me to simply overwrite the response headers OR body, or both.