### PR TITLE
Fix time format

### DIFF
--- a/lib/prmd/schema.rb
+++ b/lib/prmd/schema.rb
@@ -1,5 +1,6 @@
 require 'json'
 require 'yaml'
+require_relative 'time_to_json_schema'
 
 # :nodoc:
 module Prmd
@@ -189,6 +190,7 @@ module Prmd
     #
     # @return [String]
     def to_s
+      Time.prepend Prmd::TimeToJSONSchema
       to_json
     end
 

--- a/lib/prmd/time_to_json_schema.rb
+++ b/lib/prmd/time_to_json_schema.rb
@@ -1,0 +1,7 @@
+module Prmd
+  module TimeToJSONSchema
+    def to_json(options = {})
+      "\"#{xmlschema}\""
+    end
+  end
+end

--- a/test/schema_test.rb
+++ b/test/schema_test.rb
@@ -37,4 +37,10 @@ class SchemaTest < Minitest::Test
     user_id = user_input_schema['definitions']['user']['definitions']['id']
     assert_equal(value, { 'override' => true }.merge(user_id))
   end
+
+  def test_include_time
+    time = user_input_schema['definitions']['user']['definitions']['created_at']['example']
+    json_schema_format = "\"#{Time.parse(time).xmlschema}\""
+    assert_equal(time.to_json, json_schema_format)
+  end
 end

--- a/test/time_to_json_schema_test.rb
+++ b/test/time_to_json_schema_test.rb
@@ -1,0 +1,14 @@
+require File.expand_path('./helpers', File.dirname(__FILE__))
+
+module Prmd
+  class TimeToJSONSchemaTest < Minitest::Test
+    def time
+      Time.parse('2016-01-01 00:00:00 JST')
+    end
+
+    def test_to_json
+      Time.prepend TimeToJSONSchema
+      assert_equal time.to_json, "\"#{time.xmlschema}\""
+    end
+  end
+end


### PR DESCRIPTION
Define `date-time` validation format with RFC3339 in JSON Schema.
I encounted problem, Prmd.combine return not valid format value.

from:
```yaml
  created_at:
    description: when user was created
    format: date-time
    example: 2016-01-01T00:00:00Z
    type:
    - string
```

expect:
```json
    "created_at": {
      "description": "when user was created",
      "format": "date-time",
      "example": "2016-01-01T00:00:00Z",
      "type": [
        "string"
      ]
    },
```

got:
```json
    "created_at": {
      "description": "when user was created",
      "format": "date-time",
      "example": "2016-01-01 00:00:00 UTC",
      "type": [
        "string"
      ]
    },
```

I would like to merge this solution.
But, this solution abandoned under Ruby2.0 cause use `prepend`.