### PR TITLE
Specify install bundler version in travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: ruby
+rvm:
+- 2.0
+- 2.1
+- 2.2
+- ruby-head
 before_install:
 - gem install bundler -v '~> 1.10'
 script: "bundle exec rake"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+before_install:
+- gem install bundler -v '~> 1.10'
 script: "bundle exec rake"
 notifications:
   email: false


### PR DESCRIPTION
Latest builds on travis are broken because of bundler is too old and contains some issues.

Refs: [bundler/bundler#3558](https://github.com/bundler/bundler/issues/3558) [travis-ci/travis-ci#3531](https://github.com/travis-ci/travis-ci/issues/3531)