### PR TITLE
Allow oneOf in link schema

### DIFF
--- a/schemas/interagent-hyper-schema.json
+++ b/schemas/interagent-hyper-schema.json
@@ -122,6 +122,9 @@
                         },
                         {
                             "required": ["patternProperties", "type"]
+                        },
+                        {
+                            "required": ["oneOf"]
                         }
                     ]
                 }


### PR DESCRIPTION
I have the situation where I want to require different parameters, depending on the value of one parameter. Based on http://stackoverflow.com/a/11652478, I tried using `oneOf` in `schema` but it's not allowed at the moment.

What do you think about adding it? Or is there another way to achieve the same result using the current options?

One downside of the new approach is that all schema errors are now a non-descriptive "no subschema matched".
