### PR TITLE
Escape if data is a SchemaHash too

### DIFF
--- a/lib/prmd/commands/combine.rb
+++ b/lib/prmd/commands/combine.rb
@@ -82,7 +82,7 @@ module Prmd
         data.map! {
           |x| escape_hrefs(x)
         }
-      elsif data.is_a? Hash
+      elsif data.is_a?(Hash) || data.is_a?(Prmd::SchemaHash)
         data.each { |k,v|
           if k == 'href'
             if v.is_a? String


### PR DESCRIPTION
Otherwise only the tests pass, but combining fails because dereferencing is
errors on lib/prmd/schema.rb:90: undefined method `gsub' for nil:NilClass.

Sorry for screwing this up, should have tested the updated version with actual code. The tests lied because there `data` is a `Hash` ...