### PR TITLE
Command line flag to allow types as strings rather than arrays

### DIFF
--- a/lib/prmd/cli/combine.rb
+++ b/lib/prmd/cli/combine.rb
@@ -22,6 +22,9 @@ module Prmd
           opts.on('-o', '--output-file FILENAME', String, 'File to write result to') do |n|
             yield :output_file, n
           end
+          opts.on('-t', '--type-as-string', 'Allow type as string') do |t|
+            options[:type_as_string] = t
+          end
         end
       end
 
@@ -30,7 +33,8 @@ module Prmd
       # @example Usage
       #   Prmd::CLI::Combine.execute(argv: ['schema/schemata/api'],
       #                              meta: 'schema/meta.json',
-      #                              output_file: 'schema/api.json')
+      #                              output_file: 'schema/api.json',
+      #                              type-as-string)
       #
       # @param (see Prmd::CLI::Base#execute)
       # @return (see Prmd::CLI::Base#execute)

--- a/lib/prmd/commands/combine.rb
+++ b/lib/prmd/commands/combine.rb
@@ -119,7 +119,7 @@ module Prmd
         end
         meta ||= {}
       end
-      combiner = Prmd::Combiner.new(meta: meta, base: base, schema: schema)
+      combiner = Prmd::Combiner.new(meta: meta, base: base, schema: schema, options: options)
       combiner.combine(*schemata)
     end
 

--- a/lib/prmd/core/combiner.rb
+++ b/lib/prmd/core/combiner.rb
@@ -13,6 +13,7 @@ module Prmd
       @schema = properties.fetch(:schema)
       @base = properties.fetch(:base, {})
       @meta = properties.fetch(:meta, {})
+      @options = properties.fetch(:options, {})
     end
 
     # @param [Object] datum
@@ -53,7 +54,7 @@ module Prmd
         reference_localizer(data['definitions'][id_ary])
       end
 
-      Prmd::Schema.new(data)
+      Prmd::Schema.new(data, @options)
     end
 
     private :reference_localizer

--- a/lib/prmd/schema.rb
+++ b/lib/prmd/schema.rb
@@ -24,24 +24,24 @@ module Prmd
     attr_reader :data
 
     # @param [Hash<String, Object>] new_data
-    def initialize(new_data = {})
-      @data = convert_type_to_array(new_data)
+    def initialize(new_data = {}, options = {})
+      @data = convert_type_to_array(new_data, options)
       @schemata_examples = {}
     end
 
     #
     # @param [Object] datum
     # @return [Object] same type as the input object
-    def convert_type_to_array(datum)
+    def convert_type_to_array(datum, options)
       case datum
       when Array
-        datum.map { |element| convert_type_to_array(element) }
+        datum.map { |element| convert_type_to_array(element, options) }
       when Hash
-        if datum.key?('type') && datum['type'].is_a?(String)
+        if datum.key?('type') && datum['type'].is_a?(String) && !options[:type_as_string]
           datum['type'] = [*datum['type']]
         end
         datum.each_with_object({}) do |(k, v), hash|
-          hash[k] = convert_type_to_array(v)
+          hash[k] = convert_type_to_array(v, options)
         end
       else
         datum


### PR DESCRIPTION
The json schema library I am using to parse looks for strings rather than arrays for types.  I don't plan on using multiple types as an array so I added a flag to allow type as string.

ex: prmd combine --meta meta.json --type-as-string schemata/ > schema.json