### PR TITLE
Add example when using date format

### DIFF
--- a/docs/schemata.md
+++ b/docs/schemata.md
@@ -42,7 +42,7 @@ Each attribute MUST include the following properties:
 Each attribute MAY include the following properties:
 
 * `pattern` - a javascript regex encoded in a string that the valid values MUST match
-* `format` - format of the value. MUST be one of spec defined `["date-time", "email", "hostname", "ipv4", "ipv6", "uri"]` or defined by us `["uuid"]`
+* `format` - format of the value. MUST be one of spec defined `["date", "date-time", "email", "hostname", "ipv4", "ipv6", "uri"]` or defined by us `["uuid"]`
 
 Examples:
 

--- a/lib/prmd/schema.rb
+++ b/lib/prmd/schema.rb
@@ -10,6 +10,7 @@ module Prmd
     "number"  => 42.0,
     "string"  => "example",
 
+    "date"      => "2015-01-01",
     "date-time" => "2015-01-01T12:00:00Z",
     "email"     => "username@example.com",
     "hostname"  => "example.com",


### PR DESCRIPTION
json_schema supports it, so prmd did not fail when I used `date` as a format,
but the generated example was empty.

See
https://github.com/brandur/json_schema/blob/v0.13.0/lib/json_schema/validator.rb#L543.