### PR TITLE
don't convert type to array in example

### DIFF
--- a/lib/prmd/schema.rb
+++ b/lib/prmd/schema.rb
@@ -42,7 +42,11 @@ module Prmd
           datum['type'] = [*datum['type']]
         end
         datum.each_with_object({}) do |(k, v), hash|
-          hash[k] = convert_type_to_array(v, options)
+          if k != 'example'
+            hash[k] = convert_type_to_array(v, options)
+          else
+            hash[k] = v
+          end
         end
       else
         datum


### PR DESCRIPTION
won't convert `"type": "xxx"` to `"type": ["xxx"]` in `"example"`

sometimes I write an example as an object, if it has "type" key in anywhere, it will be changed to an array by `convert_type_to_array`.

It's really unnecessary to modify "example" in schema, I skipped it.

Why do I write object in example? because prmd won't generate examples for "patternProperties"

I have an another question, what is the propose of `convert_type_to_array`?