### PR TITLE
Stop replacing pipe char with encoded

### DIFF
--- a/lib/prmd/templates/schemata/helper.erb
+++ b/lib/prmd/templates/schemata/helper.erb
@@ -137,7 +137,7 @@
     end
 
     if value['pattern']
-      description += "<br/> **pattern:** `#{value['pattern'].gsub /\|/, '&#124;'}`"
+      description += "<br/> **pattern:** `#{value['pattern']}`"
     end
 
     if value['minLength'] || value['maxLength']


### PR DESCRIPTION
Fixes problem of &#124; being outputted because it's wrapped in a code block.