### PR TITLE
Allow digits in property names in hyper schema

### DIFF
--- a/schemas/interagent-hyper-schema.json
+++ b/schemas/interagent-hyper-schema.json
@@ -66,7 +66,7 @@
                 },
                 "properties": {
                     "patternProperties": {
-                        "^[a-z][a-zA-Z_]*[a-zA-Z]$": {
+                        "^[a-z0-9][a-zA-Z0-9_]*[a-zA-Z0-9]$": {
                             "$ref": "#/definitions/resourceProperty"
                         }
                     },


### PR DESCRIPTION
Similar to interagent#284

Couldn't see a reason why the digits are not allowed.