### PR TITLE
Import options from settings on RakeTask::Doc

### DIFF
--- a/lib/prmd/rake_tasks/doc.rb
+++ b/lib/prmd/rake_tasks/doc.rb
@@ -37,7 +37,7 @@ module Prmd
         super options, &block
         if @options[:settings].is_a? String
           settings = Prmd.load_schema_file(@options[:settings])
-          @options[:settings] = HashHelpers.deep_symbolize_keys(settings)
+          @options.merge! HashHelpers.deep_symbolize_keys(settings)
         end
         @options[:template] ||= Prmd::Template.template_dirname
       end

--- a/lib/prmd/rake_tasks/doc.rb
+++ b/lib/prmd/rake_tasks/doc.rb
@@ -5,6 +5,7 @@ require 'prmd/url_generator'
 require 'prmd/template'
 require 'prmd/schema'
 require 'prmd/link'
+require_relative '../hash_helpers'
 
 # :nodoc:
 module Prmd
@@ -34,6 +35,10 @@ module Prmd
         options = legacy_parameters(*args)
         @files = options.fetch(:files) { [] }
         super options, &block
+        if @options[:settings].is_a? String
+          settings = Prmd.load_schema_file(@options[:settings])
+          @options[:settings] = HashHelpers.deep_symbolize_keys(settings)
+        end
         @options[:template] ||= Prmd::Template.template_dirname
       end
 


### PR DESCRIPTION
When options[:settings] is provided by schema:doc block on Rakefile, but not import json file.

Used: `settings.json`

```json
{
  "doc": {
    "toc": true
  }
}
```

I add a testing code into `template/schema.rb` on line 1 (before apply this pull request)

```ruby
<%- puts options[:doc].inspect %>
```

results.

```
{:url_style=>"default", :disable_title_and_description=>false, :toc=>false}
```

So I copy settings json loading script from cli/doc.rb to rake_tasks/doc.rb . (I think, it might bad coding)

after merge this request.

```
{:url_style=>"default", :disable_title_and_description=>false, :toc=>true}
```

If my modification is bad, instead fix sample Raketask (this is example and no testing)

```
  Prmd::RakeTasks::Doc.new do |t|
    settings = Prmd.load_schema_file("docs/settings.json")
    t.options.merge(settings)
    t.files = { "docs/schema.json" => "docs/schema.md" }
  end
```