### PR TITLE
Support allOf example (testing)

### DIFF
--- a/lib/prmd/schema.rb
+++ b/lib/prmd/schema.rb
@@ -119,7 +119,7 @@ module Prmd
         ref = id_ref || value['anyOf'].first
         schema_example(ref)
       elsif value.key?('allOf')
-        value['allOf'].map { |v| schema_example(v) }.reduce({}, &:merge)
+        value['allOf'].reduce({}, &:merge).map { |v| schema_example(v) }
       elsif value.key?('properties') # nested properties
         schema_example(value)
       elsif value.key?('items') # array of objects

--- a/lib/prmd/schema.rb
+++ b/lib/prmd/schema.rb
@@ -118,6 +118,8 @@ module Prmd
         end
         ref = id_ref || value['anyOf'].first
         schema_example(ref)
+      elsif value.key?('allOf')
+        value['allOf'].map { |v| schema_example(v) }.reduce({}, &:merge)
       elsif value.key?('properties') # nested properties
         schema_example(value)
       elsif value.key?('items') # array of objects

--- a/lib/prmd/schema.rb
+++ b/lib/prmd/schema.rb
@@ -119,7 +119,7 @@ module Prmd
         ref = id_ref || value['anyOf'].first
         schema_example(ref)
       elsif value.key?('allOf')
-        value['allOf'].reduce({}, &:merge).map { |v| schema_example(v) }
+        schema_example value['allOf'].map { |s| dereference(s)[1] }.reduce({}, &:merge)
       elsif value.key?('properties') # nested properties
         schema_example(value)
       elsif value.key?('items') # array of objects

--- a/lib/prmd/schema.rb
+++ b/lib/prmd/schema.rb
@@ -119,7 +119,7 @@ module Prmd
         ref = id_ref || value['anyOf'].first
         schema_example(ref)
       elsif value.key?('allOf')
-        schema_example value['allOf'].map { |s| dereference(s)[1] }.reduce({}, &:merge)
+        value['allOf'].map { |ref| schema_example(ref) }.reduce({}, &:merge)
       elsif value.key?('properties') # nested properties
         schema_example(value)
       elsif value.key?('items') # array of objects


### PR DESCRIPTION
Enable `allOf` Example.

Before:

```
rake aborted!
NoMethodError: undefined method `[]' for nil:NilClass
/Users/shota/Docs/api.umee.be/vendor/bundle/ruby/2.4.0/gems/prmd-0.13.0/lib/prmd/schema.rb:138:in `schema_value_example'
```

in 138:

```ruby
    def schema_value_example(value)
      if value.key?('example')
        value['example']
      elsif value.key?('anyOf')
        id_ref = value['anyOf'].find do |ref|
          ref['$ref'] && ref['$ref'].split('/').last == 'id'
        end
        ref = id_ref || value['anyOf'].first
        schema_example(ref)
      elsif value.key?('properties') # nested properties
        schema_example(value)
      elsif value.key?('items') # array of objects
        _, items = dereference(value['items'])
        if value['items'].key?('example')
          if items["example"].is_a?(Array)
            items["example"]
          else
            [items['example']]
          end
        else
          [schema_example(items)]
        end
      elsif value.key?('enum')
        value['enum'][0]
      elsif DefaultExamples.key?(value["format"])
        DefaultExamples[value["format"]]
      elsif DefaultExamples.key?(value["type"][0]) # ← on line 138
        DefaultExamples[value["type"][0]]
      end
    end
```

if `value` has a `allOf` key, it's means to require combined example.