### PR TITLE
Link to api title from toc

### DIFF
--- a/lib/prmd/templates/table_of_contents.erb
+++ b/lib/prmd/templates/table_of_contents.erb
@@ -6,6 +6,6 @@
   <% _, schemata = schema.dereference(property) %>
 - <a href="#resource-<%= resource %>"><%= schemata['title'].split(' - ', 2).last %></a>
   <% schemata.fetch('links', []).each do |l| %>
-  - <a href="#link-<%= l['method'] %>-<%= resource %>-<%= l['href'] %>"><%= l['method'] %> <%= build_link_path(schema, l) %></a>
+  - <a href="#<%= schemata['title'].gsub(/\s/, '-').downcase %>-<%= l['title'].gsub(/\s/, '-').downcase %>"><%= l['method'] %> <%= build_link_path(schema, l) %></a>
   <% end %>
 <% end %>


### PR DESCRIPTION
### Description

TOC link is very usefull, but link with `{hoge}` parameter is not valid.
So I changed link target from link url to title of api description part.

### Sample

please click each toc link on these .md files.

**before**
https://github.com/ginkouno/md_link_sample/blob/master/schema_toc_link_before.md

**after**
https://github.com/ginkouno/md_link_sample/blob/master/schema_toc_link_after.md