### PR TITLE
Show union type

### DIFF
--- a/lib/prmd/templates/schemata/helper.erb
+++ b/lib/prmd/templates/schemata/helper.erb
@@ -175,7 +175,7 @@
     else
       ''
     end
-    type += (value['format'] || (value['type'] - ['null']).first)
+    type += (value['format'] || (value['type'] - ['null']).join(' or '))
     [key, type, description, example]
   end
 


### PR DESCRIPTION
When I use union type for some reason (for example, big int support), prmd documents show only first type only.

```
properties:
  id:
    description: "ID"
    type:
      - string
      - number
```

I want prmd to display all types.