### PR TITLE
Move details tags

### DIFF
--- a/lib/prmd/templates/schemata.md.erb
+++ b/lib/prmd/templates/schemata.md.erb
@@ -18,11 +18,12 @@ Stability: `<%= schemata['stability'] %>`
 <%= schemata['description'] %>
 <%- end -%>
 
+<%- if schemata['properties'] && !schemata['properties'].empty? %>
+
+### Attributes
+
 <details>
   <summary>Details</summary>
-
-<%- if schemata['properties'] && !schemata['properties'].empty? %>
-### Attributes
 
 
 | Name | Type | Description | Example |
@@ -37,6 +38,8 @@ Stability: `<%= schemata['stability'] %>`
 | **<%= name %>** | *<%= type %>* | <%= description %> | <%= example %> |
 <%- end %>
 
+</details>
+
 <%- end %>
 <%- (schemata['links'] || []).each do |link, datum| %>
 <%=
@@ -50,5 +53,3 @@ Stability: `<%= schemata['stability'] %>`
   })
 %>
 <%- end -%>
-
-</details>


### PR DESCRIPTION
By the PR (https://github.com/interagent/prmd/pull/330), we need opening details to use table of contents links now.

I guess here is a better position.

I changed

From,
```
Details >
  - Attributes (don't show when there are no properties)
  - Links
     - Details >
```

To,

```
- Attributes (don't show when there are no properties)
   - Details >
- Links
  - Details >
```