### PR TITLE
Fix toc link not working on github

### DIFF
--- a/lib/prmd/templates/schemata.md.erb
+++ b/lib/prmd/templates/schemata.md.erb
@@ -9,7 +9,7 @@
   title = schemata['title'].split(' - ', 2).last
 -%>
 <%- unless options[:doc][:disable_title_and_description] %>
-<a name="#resource-<%= resource %>"></a>
+<a name="resource-<%= resource %>"></a>
 ## <%= title %>
 
 <%- if schemata['stability'] && !schemata['stability'].empty? %>

--- a/lib/prmd/templates/schemata/link.md.erb
+++ b/lib/prmd/templates/schemata/link.md.erb
@@ -3,7 +3,7 @@
   response_example = link['response_example']
   link_schema_properties_template = Prmd::Template.load_template('link_schema_properties.md.erb', options[:template])
 -%>
-<a name="link-<%= link['method'] %>-<%= resource %>-<%= link['href'] %>"></a>
+<a name="link-<%= link['method'].downcase %>-<%= resource %>-<%= build_link_path(schema, link) %>"></a>
 ### <%= title %> <%= link['title'] %>
 
 <details>

--- a/lib/prmd/templates/table_of_contents.erb
+++ b/lib/prmd/templates/table_of_contents.erb
@@ -6,6 +6,6 @@
   <% _, schemata = schema.dereference(property) %>
 - <a href="#resource-<%= resource %>"><%= schemata['title'].split(' - ', 2).last %></a>
   <% schemata.fetch('links', []).each do |l| %>
-  - <a href="#link-<%= l['method'] %>-<%= resource %>-<%= l['href'] %>"><%= l['method'] %> <%= build_link_path(schema, l) %></a>
+  - <a href="#link-<%= l['method'].downcase %>-<%= resource %>-<%= build_link_path(schema, l) %>"><%= l['method'] %> <%= build_link_path(schema, l) %></a>
   <% end %>
 <% end %>

--- a/test/commands/render_test.rb
+++ b/test/commands/render_test.rb
@@ -39,8 +39,9 @@ class InteragentRenderTest < Minitest::Test
 
     assert_match /^## The table of contents/, markdown
     assert_match '<a href="#resource-app"', markdown
-    assert_match '- <a href="#link-POST-app-/apps">POST /apps', markdown
-    assert_match '<a name="link-POST-app-/apps"></a>', markdown
+    assert_match '<a name="resource-app"', markdown
+    assert_match '- <a href="#link-post-app-/apps">POST /apps', markdown
+    assert_match '<a name="link-post-app-/apps"></a>', markdown
   end
 
   def test_render_for_example_as_an_array


### PR DESCRIPTION
relate to https://github.com/interagent/prmd/pull/331

Some toc links doesn't work on github.
I couldn't find the exact cause but I think some github function changing markdown file make the problem.

If we use name attribute of a tag in markdown file, github add `user-content` prefix and downcase words.

example
```
# before
link-GET-shop-/api/shops

# after
user-content-link-get-shop-/api/shops
```

I tried some cases.

```
# work
<a href="#link-GET-shop-/api/shops">GET /api/shops</a>
<a name="user-content-link-get-shop-/api/shops">Shop Shop Search API</a>

# not work
<a href="#link-GET-shop-/api/shops/{(%23%2Fdefinitions%2Fshop%2Fdefinitions%2Fid)}">GET /api/shops/{shop_id}</a>
<a name="user-content-link-get-shop-/api/shops/{(%23%2fdefinitions%2fshop%2fdefinitions%2fid)}">Shop Shop Detail API</a>

# work
<a href="#link-GET-shop-/api/shops/{shop_id}">GET /api/shops/{shop_id}</a>
<a name="user-content-link-get-shop-/api/shops/{shop_id}">Shop Shop Search API</a>
```

I don't know the cause but this fix work well and I think more simple than before.