### PR TITLE
Fix travis bundler version error

### DIFF
--- a/prmd.gemspec
+++ b/prmd.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'erubis',      '~> 2.7'
   spec.add_dependency 'json_schema', '~> 0.3', '>= 0.3.1'
 
-  spec.add_development_dependency 'bundler',  '~> 1.3'
+  spec.add_development_dependency 'bundler',  '>= 1.3'
   spec.add_development_dependency 'rake',     '~> 10.3'
   spec.add_development_dependency 'minitest', '~> 5.4'
 end


### PR DESCRIPTION
rvm ruby-head bundle bundler 2.0.1.
bundler version in gemspec is just development_dependency so I think this is safe and ok.
Thank you.