### PR TITLE
Escape patterns (regexes) in markdown

### DIFF
--- a/lib/prmd/templates/schemata/helper.erb
+++ b/lib/prmd/templates/schemata/helper.erb
@@ -137,7 +137,10 @@
     end
 
     if value['pattern']
-      description += "<br/> **pattern:** `#{value['pattern']}`"
+      # Prevent the pipe regex pattern characters from being interpreted as markdown table:
+      pattern = value['pattern'].gsub(/\|/, '&#x7c;')
+
+      description += "<br/> **pattern:** <pre>#{pattern}</pre>"
     end
 
     if value['minLength'] || value['maxLength']

--- a/test/commands/render_test.rb
+++ b/test/commands/render_test.rb
@@ -50,6 +50,12 @@ class InteragentRenderTest < Minitest::Test
     assert_match expression, markdown
   end
 
+  def test_render_for_regex_patterns_with_pipes
+    expression = /<pre>\(\^first\$&#x7c;\^second\$\)<\/pre> \| \`"second"\` \|\n/
+    markdown = render
+    assert_match expression, markdown
+  end
+
   private
 
   def data
@@ -113,6 +119,12 @@ class InteragentRenderTest < Minitest::Test
               'example' => 'OPTION2',
               'enum' => 'OPTION2'
             },
+            'patterned-string' => {
+              'description' => 'A string with a regex pattern applied to it.',
+              'type' => 'string',
+              'example' => 'second',
+              'pattern' => '(^first$|^second$)'
+            },
             'option1' => {
               'properties' => {
                 'type' => {
@@ -175,7 +187,10 @@ class InteragentRenderTest < Minitest::Test
             },
             'options' => {
               '$ref' => '#/definitions/config-var/definitions/options'
-            }
+            },
+            'patterned-string' => {
+              '$ref' => '#/definitions/config-var/definitions/patterned-string'
+            },
           }
         }
       },


### PR DESCRIPTION
This fixes a bug observed with the Heroku Platform API schema markdown, which is that when it puts a "pattern" in a table like this, the pipe gets interpreted as part of the markdown table, even though it is inside a code block. The solution for this is to render the pattern part in a `<pre></pre>` tag with an htmlentity for the pipe.

Here's what the bug looks like:
```markdown
| **deploy_target:id** | *string* | unique identifier of deploy target<br/> **pattern:** `(^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$|^[a-z]{2}$)` | `"us"` |
| **deploy_target:type** | *string* | type of deploy target<br/> **pattern:** `(^space$|^region$)` | `"region"` |
```
becomes:

![image](https://user-images.githubusercontent.com/3340/96035396-9a970000-0e28-11eb-9511-6aab7085c541.png)
