### PR TITLE
Remove ruby versions older than 2.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: ruby
 rvm:
-- 2.3.4
-- 2.4.1
+- 2.3.8
+- 2.4.10
+- 2.5.8
+- 2.6.6
+- 2.7.2
 - ruby-head
 before_install:
-- gem install bundler -v '~> 1.10'
+- gem install bundler -v '~> 2.0'
 script: "bundle exec rake"
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: ruby
 rvm:
-- 2.0
-- 2.1
-- 2.2
 - 2.3.4
 - 2.4.1
 - ruby-head


### PR DESCRIPTION
@mathias pointed out in https://github.com/interagent/prmd/pull/345 that the old ruby versions do not pass.  I attempted to get this to work locally with an ancient 2.2 version of ruby I had lying around and it fails because bundler 2.x only supports rubies >= 2.3.0.  Since support for 2.3 ended in [2019](https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/) I think it would be okay to remove ruby versions.  While I was in here I went ahead and added the latest ruby versions and updated the other ones to latest versions.

```
rbriggs@rbriggs-ltl [10:15:40 AM] [~/src/github.com/interagent/prmd] [master]
-> % bundle install
Fetching gem metadata from https://rubygems.org/..
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    bundler (~> 2.0)

  Current Bundler version:
    bundler (1.17.0)
This Gemfile requires a different version of Bundler.
Perhaps you need to update Bundler by running `gem install bundler`?

Could not find gem 'bundler (~> 2.0)' in any of the relevant sources:
  the local ruby installation
rbriggs@rbriggs-ltl [10:15:44 AM] [~/src/github.com/interagent/prmd] [master]
-> % gem install bundler
Fetching: bundler-2.1.4.gem (100%)
ERROR:  Error installing bundler:
	bundler requires Ruby version >= 2.3.0.
```