### PR TITLE
ensure regexp in tables is rendered correctly

### DIFF
--- a/lib/prmd/templates/schemata/helper.erb
+++ b/lib/prmd/templates/schemata/helper.erb
@@ -138,10 +138,15 @@
 
     if value['pattern']
       # Prevent the pipe regex pattern characters from being interpreted
-      # as markdown table
+      # as markdown table.
       # Prevent instances of []() in regexes from being rendered as
-      # markdown links
-      pattern = value['pattern'].gsub(/\|/, '&#124;').gsub(/\[/, '&#91;')
+      # markdown links.
+      # Prevent patterns with * being rendered as having emphasis
+      # or being an unordered list.
+      pattern = value['pattern']
+        .gsub(/\|/, '&vert;')
+        .gsub(/\[/, '&lbrack;')
+        .gsub(/\*/, '&ast;')
 
       description += "<br/> **pattern:** <pre>#{pattern}</pre>"
     end

--- a/lib/prmd/templates/schemata/helper.erb
+++ b/lib/prmd/templates/schemata/helper.erb
@@ -137,8 +137,11 @@
     end
 
     if value['pattern']
-      # Prevent the pipe regex pattern characters from being interpreted as markdown table:
-      pattern = value['pattern'].gsub(/\|/, '&#x7c;')
+      # Prevent the pipe regex pattern characters from being interpreted
+      # as markdown table
+      # Prevent instances of []() in regexes from being rendered as
+      # markdown links
+      pattern = value['pattern'].gsub(/\|/, '&#124;').gsub(/\[/, '&#91;')
 
       description += "<br/> **pattern:** <pre>#{pattern}</pre>"
     end

--- a/test/commands/render_test.rb
+++ b/test/commands/render_test.rb
@@ -51,7 +51,7 @@ class InteragentRenderTest < Minitest::Test
   end
 
   def test_render_for_regex_patterns_with_pipes
-    expression = /<pre>\^&#91;a-z\]\(\?:&#91;a-z\]&#x7c;\)\+&#91;a-z\]\$/
+    expression = /<pre>\^&lbrack;a-z\]\(\?:&lbrack;a&vert;b\]\)\&ast;&lbrack;a-z]&ast;\$/
     markdown = render
     assert_match expression, markdown
   end
@@ -123,7 +123,7 @@ class InteragentRenderTest < Minitest::Test
               'description' => 'A string with a regex pattern applied to it.',
               'type' => 'string',
               'example' => 'second',
-              'pattern' => '^[a-z](?:[a-z]&#x7c;)+[a-z]$'
+              'pattern' => '^[a-z](?:[a|b])*[a-z]*$'
             },
             'option1' => {
               'properties' => {

--- a/test/commands/render_test.rb
+++ b/test/commands/render_test.rb
@@ -51,7 +51,7 @@ class InteragentRenderTest < Minitest::Test
   end
 
   def test_render_for_regex_patterns_with_pipes
-    expression = /<pre>\(\^first\$&#x7c;\^second\$\)<\/pre> \| \`"second"\` \|\n/
+    expression = /<pre>\^&#91;a-z\]\(\?:&#91;a-z\]&#x7c;\)\+&#91;a-z\]\$/
     markdown = render
     assert_match expression, markdown
   end
@@ -123,7 +123,7 @@ class InteragentRenderTest < Minitest::Test
               'description' => 'A string with a regex pattern applied to it.',
               'type' => 'string',
               'example' => 'second',
-              'pattern' => '(^first$|^second$)'
+              'pattern' => '^[a-z](?:[a-z]&#x7c;)+[a-z]$'
             },
             'option1' => {
               'properties' => {


### PR DESCRIPTION
In https://github.com/interagent/prmd/pull/345/ a bug was fixed where a regexp containing a pipe character would close the table cell it was in. Because the fix uses `<pre>` instead of the backticks notation for inline code in markdown, the content of the `<pre>` element was being parsed as markdown.

It is not unusual for a regexp to contain what looks like a markdown link (`[...](...)`) so that introduced a new bug.

I believe this PR will fix that bug, while introducing a new test case for them