### PR TITLE
Fix broken rendering in case of Array with +oneOf+

### DIFF
--- a/lib/prmd/templates/schemata/helper.erb
+++ b/lib/prmd/templates/schemata/helper.erb
@@ -59,7 +59,7 @@
           oneof_name = ref ? ref.split('/').last : index
           nested = extract_attributes(schema, oneof_definition['properties'])
           nested.each do |attribute|
-            attribute[0] = "#{key}/[#{oneof_name.upcase}].#{attribute[0]}"
+            attribute[0] = "#{key}/[#{oneof_name.to_s.upcase}].#{attribute[0]}"
           end
           attributes.concat(nested)
         end


### PR DESCRIPTION
If the schemas provided inside `oneOf` of array items is not a `ref`,
the rendering fails because it tries `.upcase` on an `Integer`.