### PR TITLE
Fix +name+ for resource anchors

### DIFF
--- a/lib/prmd/templates/schemata.md.erb
+++ b/lib/prmd/templates/schemata.md.erb
@@ -9,7 +9,7 @@
   title = schemata['title'].split(' - ', 2).last
 -%>
 <%- unless options[:doc][:disable_title_and_description] %>
-<a name="#resource-<%= resource %>"></a>
+<a name="resource-<%= resource %>"></a>
 ## <%= title %>
 
 <%- if schemata['stability'] && !schemata['stability'].empty? %>


### PR DESCRIPTION
+name+ attribute should not have the +#+ for the links to this anchor to
work.