### PR TITLE
Use YAML.unsafe_load when it is available

### DIFF
--- a/lib/prmd/multi_loader/yaml.rb
+++ b/lib/prmd/multi_loader/yaml.rb
@@ -9,7 +9,11 @@ module Prmd #:nodoc:
 
       # @see (Prmd::MultiLoader::Loader#load_data)
       def self.load_data(data)
-        ::YAML.load(data)
+        if ::YAML.respond_to?(:unsafe_load)
+          ::YAML.unsafe_load(data)
+        else
+          ::YAML.load(data)
+        end
       end
 
       # register this loader for all .yaml and .yml files


### PR DESCRIPTION
Use `YAML.unsafe_load` method when it is available.

This resolves an [incompatibility in Psych 4.0.0](https://bugs.ruby-lang.org/issues/17866).